### PR TITLE
DD-12: Webform integration

### DIFF
--- a/READ_ME
+++ b/READ_ME
@@ -1,1 +1,0 @@
-webform-manualdd

--- a/js/webform_manualdd.js
+++ b/js/webform_manualdd.js
@@ -1,0 +1,92 @@
+CRM.$(document).ready(function ($) {
+  Drupal.behaviors.webformManualDirectDebit = {
+    attach: function (context, settings) {
+
+      var billingEmailMessages = [];
+      var paymentProcessorId = Drupal.settings.webformManualDirectDebit.paymentProcessorId;
+      var customGroupId = Drupal.settings.webformManualDirectDebit.customGroupId;
+
+      if (!paymentProcessorId) {
+        return false;
+      }
+      var isPaymentProcessorEqualDirectDebit = $('[name=civicrm_1_contribution_1_contribution_payment_processor_id]').val() == paymentProcessorId;
+
+      if (isPaymentProcessorEqualDirectDebit) {
+        billingMessagesForAllContacts()
+      }
+
+      $('[name=civicrm_1_contribution_1_contribution_payment_processor_id]').change(function () {
+        billingMessagesForAllContacts()
+      });
+
+      function billingMessagesForAllContacts() {
+        var numberOfContacts = $('[name=number_of_contacts]').val();
+        for (var i = 1; i <= numberOfContacts; i++) {
+          createMessage(i);
+        }
+      }
+
+      function createMessage(contactSerialNumber) {
+        var isPaymentProcessorEqualDirectDebit = $('[name=civicrm_1_contribution_1_contribution_payment_processor_id]').val() == paymentProcessorId;
+        var isContactDirectDebitMandateFieldsEmpty = $('[name=contact_' + contactSerialNumber + '_number_of_cg' + customGroupId + ']').val() == '0';
+        if (isPaymentProcessorEqualDirectDebit && isContactDirectDebitMandateFieldsEmpty) {
+          showErrorMessage(contactSerialNumber);
+        } else {
+          $('.wf-crm-billing-dd_mandate_contact_' + contactSerialNumber).remove();
+          billingEmailMessages[contactSerialNumber] &&
+          billingEmailMessages[contactSerialNumber].close &&
+          billingEmailMessages[contactSerialNumber].close();
+        }
+
+        return false;
+      }
+
+      function showErrorMessage(contactSerialNumber) {
+        var selectedPage = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
+        var extensionErrorMessageBlock = $('.wf-crm-billing-dd_mandate_contact_' + contactSerialNumber);
+        var message = Drupal.t('You must enable an Direct Debit mandate fieldset for Contact% in order to process transactions.',
+          {'Contact%': getContactLabel(contactSerialNumber)});
+
+        var isErrorMessageExist = extensionErrorMessageBlock.length;
+        if (!isErrorMessageExist) {
+          selectedPage.after(
+            '<div class="messages error wf-crm-billing-dd_mandate_contact_' + contactSerialNumber + '">' +
+            message +
+            ' <button data-contact="' + contactSerialNumber + '">' +
+            Drupal.t('Enable It') +
+            '</button></div>'
+          );
+
+          $('.wf-crm-billing-dd_mandate_contact_' + contactSerialNumber + ' button').click(function () {
+            var contact = $(this).data('contact');
+            $('select[name=contact_' + contact + '_number_of_cg' + customGroupId + ']').val('1').change();
+
+            return false;
+          });
+        }
+
+        var isErrorMessageHidden = extensionErrorMessageBlock.is(':hidden');
+        if (isErrorMessageHidden) {
+          billingEmailMessages[contactSerialNumber] = CRM.alert(message, Drupal.t('Direct Debit Mandate Required'), 'error');
+        }
+      }
+
+      function getContactLabel(contactSerialNumber) {
+        var contactLabel = $('input[name=' + contactSerialNumber + '_webform_label]', '#wf-crm-configure-form').val();
+        contactLabel = checkLabelLength(contactLabel);
+
+        return contactLabel
+      }
+
+      function checkLabelLength(contactLabel) {
+        var maxLabelLength = 40;
+        contactLabel = Drupal.checkPlain(contactLabel);
+        if (contactLabel.length > maxLabelLength) {
+          contactLabel = contactLabel.substr(0, 38) + '...';
+        }
+
+        return contactLabel;
+      }
+    }
+  }
+}(jQuery));

--- a/webform_manualdd.info
+++ b/webform_manualdd.info
@@ -1,0 +1,11 @@
+name = Webform-ManualDD
+core = 7.x
+
+version = "7.x-1.3"
+package = CiviCRM
+project = "custom"
+
+dependencies[] = civicrm (>=4.7)
+dependencies[] = webform (>=4.12)
+dependencies[] = options_element
+dependencies[] = webform_civicrm

--- a/webform_manualdd.module
+++ b/webform_manualdd.module
@@ -10,9 +10,10 @@ function webform_manualdd_form_alter(&$form, &$form_state, $form_id) {
     civicrm_initialize();
     $result = civicrm_api3('Extension', 'get', [
       'full_name' => "uk.co.compucorp.manualdirectdebit",
+      'sequential' => "1",
     ]);
 
-    if ($result['count'] < 0 && $result[0]['statusLabel'] != 'Enabled') {
+    if ($result['count'] < 0 && $result['values'][0]['statusLabel'] != 'Enabled') {
       return FALSE;
     }
 

--- a/webform_manualdd.module
+++ b/webform_manualdd.module
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Implements of hook form_alter()
+ */
+function webform_manualdd_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'wf_crm_configure_form') {
+
+    //  checks if extension exist
+    civicrm_initialize();
+    $result = civicrm_api3('Extension', 'get', [
+      'full_name' => "uk.co.compucorp.manualdirectdebit",
+    ]);
+
+    if ($result['count'] < 0 && $result[0]['statusLabel'] != 'Enabled') {
+      return FALSE;
+    }
+
+    //  gets Payment Processor
+    $paymentProcessor = civicrm_api3('PaymentProcessor', 'getsingle', [
+      'name' => "Direct Debit",
+    ]);
+
+    //  gets custom Fields
+    $directDebitMandateCustomFields = civicrm_api3('CustomField', 'get', [
+      'sequential' => 1,
+      'custom_group_id' => "direct_debit_mandate",
+    ]);
+
+    //  checks if Payment Processor and  Direct Debit Mandate custom fields exist
+    if (!$directDebitMandateCustomFields['count'] || !empty($paymentProcessor['is_error'])) {
+      return FALSE;
+    }
+
+    $directDebitMandateCustomGroupId = 0;
+    $requiredFields = [];
+    $searchFields = [
+      'bank_name',
+      'account_holder_name',
+      'ac_number',
+      'sort_code',
+      'dd_code',
+    ];
+
+    // finds id of direct debit mandate custom group and required field
+    foreach ($directDebitMandateCustomFields['values'] as $value) {
+      if (!$directDebitMandateCustomGroupId) {
+        $directDebitMandateCustomGroupId = $value['custom_group_id'];
+      }
+
+      if (in_array($value['name'], $searchFields)) {
+        // find which field is required
+        $requiredFields[$value['name']] = $value['id'];
+      }
+    }
+
+    // settings for js
+    $settings = [
+      'webformManualDirectDebit' => [
+        'paymentProcessorId' => $paymentProcessor['id'],
+        'customGroupId' => $directDebitMandateCustomGroupId,
+      ],
+    ];
+    drupal_add_js($settings, 'setting');
+    drupal_add_js(drupal_get_path('module', 'webform_manualdd') . '/js/webform_manualdd.js');
+
+    //finds number of contacts
+    $numberOfContacts = $form['number_of_contacts']['#default_value'];
+
+    // sets   required fields and 'checked' attributes for each contacts
+    for ($i = 1; $i <= $numberOfContacts; $i++) {
+      $amountOfMandatesForCurrentUser = $form['contact_' . $i]['contact_' . $i . '_number_of_cg' . $directDebitMandateCustomGroupId]['#default_value'];
+      if (!isset($amountOfMandatesForCurrentUser)) {
+        continue;
+      }
+      for ($j = 1; $j <= $amountOfMandatesForCurrentUser; $j++) {
+        foreach ($requiredFields as $requiredField) {
+          $form['contact_' . $i][$i . 'cg' . $directDebitMandateCustomGroupId . '_wrapper'][$i . 'cg' . $directDebitMandateCustomGroupId . $j . '_fieldset']['civicrm_' . $i . '_contact_' . $j . '_cg' . $directDebitMandateCustomGroupId . '_custom_' . $requiredField]['#attributes']['checked'] = 'checked';
+          $form['contact_' . $i][$i . 'cg' . $directDebitMandateCustomGroupId . '_wrapper'][$i . 'cg' . $directDebitMandateCustomGroupId . $j . '_fieldset']['civicrm_' . $i . '_contact_' . $j . '_cg' . $directDebitMandateCustomGroupId . '_custom_' . $requiredField]['#required'] = TRUE;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

1. "You must enable an Direct Debit mandate fieldset for Contact x in order to process transactions." notice appears on Webform Civicrm's contribution tab when "Direct Debit" payment processor is enabled.
2. A "Enable it" button appears at the end of the notice in point 1 and allow admin to enable the Direct Debit mandate fieldset for the contact.
3. Other direct debit mandate fields are added that admin can optionally enabled some of them manually.

![dd-12](https://user-images.githubusercontent.com/36959503/37588916-539924a4-2b6c-11e8-9ea3-d9f2238ce472.gif)

 


