### PR TITLE
DD-12: Show notice whenever "User Select" is selected as payment processor

### DIFF
--- a/js/webform_manualdd.js
+++ b/js/webform_manualdd.js
@@ -9,14 +9,15 @@ CRM.$(document).ready(function ($) {
       if (!paymentProcessorId) {
         return false;
       }
-      var isPaymentProcessorEqualDirectDebit = $('[name=civicrm_1_contribution_1_contribution_payment_processor_id]').val() == paymentProcessorId;
 
-      if (isPaymentProcessorEqualDirectDebit) {
-        billingMessagesForAllContacts()
-      }
+        billingMessagesForAllContacts();
 
       $('[name=civicrm_1_contribution_1_contribution_payment_processor_id]').change(function () {
-        billingMessagesForAllContacts()
+        billingMessagesForAllContacts();
+      });
+
+      $('#edit-civicrm-1-contribution-1-contribution-contribution-page-id').change(function () {
+          billingMessagesForAllContacts();
       });
 
       function billingMessagesForAllContacts() {
@@ -27,9 +28,8 @@ CRM.$(document).ready(function ($) {
       }
 
       function createMessage(contactSerialNumber) {
-        var isPaymentProcessorEqualDirectDebit = $('[name=civicrm_1_contribution_1_contribution_payment_processor_id]').val() == paymentProcessorId;
         var isContactDirectDebitMandateFieldsEmpty = $('[name=contact_' + contactSerialNumber + '_number_of_cg' + customGroupId + ']').val() == '0';
-        if (isPaymentProcessorEqualDirectDebit && isContactDirectDebitMandateFieldsEmpty) {
+        if (isSelectedPaymentProcessorMustHaveMessage() && isContactDirectDebitMandateFieldsEmpty) {
           showErrorMessage(contactSerialNumber);
         } else {
           $('.wf-crm-billing-dd_mandate_contact_' + contactSerialNumber).remove();
@@ -86,6 +86,14 @@ CRM.$(document).ready(function ($) {
         }
 
         return contactLabel;
+      }
+
+      function isSelectedPaymentProcessorMustHaveMessage() {
+        var isPaymentProcessorUserSelect = $('[name=civicrm_1_contribution_1_contribution_payment_processor_id]').val() == "create_civicrm_webform_element";
+        var isDirectDebitPaymentProcessorInOptionList = 'Direct Debit' == $('[name=civicrm_1_contribution_1_contribution_payment_processor_id] option[value=' + paymentProcessorId + ']').html()
+        var isPaymentProcessorEqualDirectDebit = $('[name=civicrm_1_contribution_1_contribution_payment_processor_id]').val() == paymentProcessorId;
+
+        return (isPaymentProcessorUserSelect && isDirectDebitPaymentProcessorInOptionList) || isPaymentProcessorEqualDirectDebit
       }
     }
   }

--- a/js/webform_manualdd.js
+++ b/js/webform_manualdd.js
@@ -44,7 +44,7 @@ CRM.$(document).ready(function ($) {
       function showErrorMessage(contactSerialNumber) {
         var selectedPage = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
         var extensionErrorMessageBlock = $('.wf-crm-billing-dd_mandate_contact_' + contactSerialNumber);
-        var message = Drupal.t('You must enable an Direct Debit mandate fieldset for Contact% in order to process transactions.',
+        var message = Drupal.t('You must enable Direct Debit mandate fieldset for Contact% in order to process transactions.',
           {'Contact%': getContactLabel(contactSerialNumber)});
 
         var isErrorMessageExist = extensionErrorMessageBlock.length;


### PR DESCRIPTION
## Overview

"You must enable an Direct Debit mandate fieldset for Contact x in order to process transactions." notice appears on Webform CiviCRM's contribution tab when "User Select" from Payment Processor dropdown  is selected.

![dd12_fix](https://user-images.githubusercontent.com/36959503/37777276-cded502e-2def-11e8-877f-76b689a65696.gif)
