### PR TITLE
BASW-756: Fix mandate to payment plan and contributions attachment and dates calculation logic

### DIFF
--- a/webform_manualdd.install
+++ b/webform_manualdd.install
@@ -1,0 +1,21 @@
+<?php
+
+function webform_manualdd_install() {
+  _webform_manualdd_make_hook_priority_lower_than_membershipextras_module();
+}
+
+function webform_manualdd_update_1000() {
+  _webform_manualdd_make_hook_priority_lower_than_membershipextras_module();
+}
+
+/**
+ * Manual direct debit module and extension depend on Membershipextras
+ * Module and extension, and thus hooks in this module should be executed
+ * after the hooks in Membershipextras.
+ * Here we achieve that by increasing the weight of this module to be
+ * higher than Membershipextras module, since hooks are executed
+ * for modules with lower weight values first.
+ */
+function _webform_manualdd_make_hook_priority_lower_than_membershipextras_module() {
+  db_query("UPDATE {system} SET weight = 1001 WHERE name = 'webform_manualdd'");
+}

--- a/webform_manualdd.module
+++ b/webform_manualdd.module
@@ -89,3 +89,77 @@ function webform_manualdd_form_alter(&$form, &$form_state, $form_id) {
     }
   }
 }
+
+/**
+ * Implements webformmembershipextras_preCreatingUpfrontContributions
+ * hook that is defined inside "Webform CiviCRM Membership Extras" module
+ * to allow us to attach the recurring contribution and the first
+ * installment to the created mandate, and to allow us to alter the
+ * installments receive date to follow Direct Debit dates calculation
+ * logic, in case the user is paying with Direct Debit payment processor,
+ * right before creating the rest of the installments.
+ *
+ * @param object $node
+ * @param int $contributionRecurId
+ */
+function webformmembershipextras_preCreatingUpfrontContributions($node, $contributionRecurId) {
+  $isDirectDebitPaymentProcessor = _webformmanualdd_isPaymentPlanPaidWithDirectDebit($contributionRecurId);
+  if (!$isDirectDebitPaymentProcessor) {
+    return;
+  }
+
+  // Attaching the mandate to both the first installment and the recurring contribution
+  $contactId = _webformmanualdd_getContactId($node);
+  $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+  $mandateId = $storageManager->getLastInsertedMandateId($contactId);
+  $storageManager->assignMandate($mandateId, $contactId);
+}
+
+/**
+ * Checks if the payment plan is paid with direct debit
+ * or not.
+ *
+ * @param int $contributionRecurId
+ * @return bool
+ */
+function _webformmanualdd_isPaymentPlanPaidWithDirectDebit($contributionRecurId) {
+  $paymentProcessorId = civicrm_api3('ContributionRecur', 'get', [
+    'sequential' => 1,
+    'return' => ['payment_processor_id'],
+    'id' => $contributionRecurId,
+  ]);
+  if (empty($paymentProcessorId['values'][0]['payment_processor_id'])) {
+    return FALSE;
+  }
+  $paymentProcessorId = $paymentProcessorId['values'][0]['payment_processor_id'];
+
+  $paymentProcessorName = civicrm_api3('PaymentProcessor', 'get', [
+    'sequential' => 1,
+    'return' => ['name'],
+    'id' => $paymentProcessorId,
+  ]);
+  if (empty($paymentProcessorName ['values'][0]['name'])) {
+    return FALSE;
+  }
+  $paymentProcessorName = $paymentProcessorName['values'][0]['name'];
+
+
+  return $paymentProcessorName === 'Direct Debit';
+}
+
+/**
+ * Gets the CiviCRM contact associated with the
+ * webform submission.
+ *
+ * @param $node
+ * @return |null
+ */
+function _webformmanualdd_getContactId($node) {
+  $civiWebformEntityProperty = _membershipextras_getCiviWebformPostprocessorPropertyValue($node, 'ent');
+
+  if (empty($civiWebformEntityProperty['contact'][1]['id'])) {
+    return NULL;
+  }
+
+  return $civiWebformEntityProperty['contact'][1]['id'];
+}

--- a/webform_manualdd.module
+++ b/webform_manualdd.module
@@ -113,8 +113,7 @@ function webform_manualdd_webformmembershipextras_preCreatingUpfrontContribution
   $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
   $mandateId = $storageManager->getLastInsertedMandateId($contactId);
   $storageManager->assignMandate($mandateId, $contactId);
-
-
+  
   $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
   $settings = $settingsManager->getManualDirectDebitSettings();
   $mandateInfo = $storageManager->getMandate($mandateId);
@@ -155,7 +154,6 @@ function _webformmanualdd_isPaymentPlanPaidWithDirectDebit($contributionRecurId)
   }
   $paymentProcessorName = $paymentProcessorName['values'][0]['name'];
 
-
   return $paymentProcessorName === 'Direct Debit';
 }
 
@@ -163,8 +161,8 @@ function _webformmanualdd_isPaymentPlanPaidWithDirectDebit($contributionRecurId)
  * Gets the CiviCRM contact associated with the
  * webform submission.
  *
- * @param $node
- * @return |null
+ * @param object $node
+ * @return int|null
  */
 function _webformmanualdd_getContactId($node) {
   $civiWebformEntityProperty = _membershipextras_getCiviWebformPostprocessorPropertyValue($node, 'ent');

--- a/webform_manualdd.module
+++ b/webform_manualdd.module
@@ -102,7 +102,7 @@ function webform_manualdd_form_alter(&$form, &$form_state, $form_id) {
  * @param object $node
  * @param int $contributionRecurId
  */
-function webformmembershipextras_preCreatingUpfrontContributions($node, $contributionRecurId) {
+function webform_manualdd_webformmembershipextras_preCreatingUpfrontContributions($node, $contributionRecurId) {
   $isDirectDebitPaymentProcessor = _webformmanualdd_isPaymentPlanPaidWithDirectDebit($contributionRecurId);
   if (!$isDirectDebitPaymentProcessor) {
     return;

--- a/webform_manualdd.module
+++ b/webform_manualdd.module
@@ -113,6 +113,18 @@ function webformmembershipextras_preCreatingUpfrontContributions($node, $contrib
   $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
   $mandateId = $storageManager->getLastInsertedMandateId($contactId);
   $storageManager->assignMandate($mandateId, $contactId);
+
+
+  $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+  $settings = $settingsManager->getManualDirectDebitSettings();
+  $mandateInfo = $storageManager->getMandate($mandateId);
+
+  // Updating both the first installment receive date and the recurring contribution start date
+  // to follow Direct Debit dates calculation logic.
+  $contributionDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator($contactId, $settings);
+  $contributionDataGenerator->setMandateStartDate($mandateInfo->start_date);
+  $contributionDataGenerator->generateContributionFieldsValues();
+  $contributionDataGenerator->saveGeneratedContributionValues();
 }
 
 /**


### PR DESCRIPTION
## Before
Purchasing memberships with a Payment plan using "Direct Debit" payment processor no longer attach the mandate to the recurring contribution and the related installments,  even though the mandate is still being getting created. The installments receive date is also no longer follows the direct debit dates calculation specs.

![2021-06-04 19_16_20-Groove Music](https://user-images.githubusercontent.com/6275540/120832558-b3d7f280-c558-11eb-8b32-096575b37e14.png)

![2021-06-04 19_16_36-Groove Music](https://user-images.githubusercontent.com/6275540/120832571-b6d2e300-c558-11eb-9e63-29512db69666.png)


![2021-06-04 19_18_07-Direct Debit Configurations _ compuvag6one](https://user-images.githubusercontent.com/6275540/120832722-de29b000-c558-11eb-97c1-d40040fbc1f7.png)


![2021-06-04 19_16_45-](https://user-images.githubusercontent.com/6275540/120832580-b9cdd380-c558-11eb-8a10-182990f3486e.png)



## After
Purchasing memberships with a Payment plan using "Direct Debit" payment processor attaches the mandate to all the payment plan installments and to the recurring contribution itself, also the dates follow the direct debit dates calculation specs.


![2021-06-04 19_23_51-Groove Music](https://user-images.githubusercontent.com/6275540/120833472-c0107f80-c559-11eb-9528-441d661a1bce.png)

![2021-06-04 19_24_06-Groove Music](https://user-images.githubusercontent.com/6275540/120833488-c272d980-c559-11eb-9827-48dd1b349d9f.png)

![2021-06-04 19_24_25-sdldsa@dada com sdldsa@dada com _ compuvag6one](https://user-images.githubusercontent.com/6275540/120833494-c4d53380-c559-11eb-9968-d114674fc713.png)



## Technical details

The fix in this PR is an alternative to the one done here: https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/239

The other solution check for a certain class "called wf_crm_webform_postprocess" and if it exists, then it assumes the post Contribution hook is called from webform context, and thus it runs the rest of the code in that PR based on this assumption.

But there are two issues with that solution:

1- The direct debit extension does not depend on the webform module, and thus it should not know about its existence, so to solve this I moved the code to this module, which is basically here to provide support for direct debit inside the webform module, so it makes more sense to use it instead.

2- The link between the mandate, the recurring contribution, and the installments is not the only issue that happened after the last webform_civicrm version, but also the logic that calculates the installments receive date based on the direct debit calculation specs is also broken. 

3- We usually hide the mandate reference and mandate start fields when configuring direct debit webforms, since these fields should be generated automatically, and that solution does not do that and rather assume they should be supplied by the user.


So now getting back to the issue at hand, and as mentioned in the previous PR, these issues started to happen after  webform_civicrm version 7.x-4.28-patch8, and specifically by this PR  https://github.com/compucorp/webform_civicrm/pull/36 PR. The details of this issue are already mentioned in the previous PR, and thus I will talk here more about my solution.

My solution implements a new hook that is defined in this PR: https://github.com/compucorp/webform_civicrm_membership_extras/pull/34 (inside webform_civicrm_membership_extras module), which is invoked right before creating the upfront installments  (hence that the webform_civicrm module will handle the creation of the payment plan and the first installment only, so if we have 12 installments in total, so only the first one will be created at the time of invoking the hook.

The rest of the solution sets in this module, here I implement the hook above and:

1- Ensure that the payment processor used is Direct debit processor (because if not then there is no mandate to being with and thus we return early).
2- Then I use CRM_ManualDirectDebit_Common_MandateStorageManager class to get the last mandate attached to the contact since the last mandate will be the one just got created by the webform submission, and then I use the same class "assignMandate" method to assign the mandate to the recurring contribution and first installment, the "assignMandate" method only needs the contact id and the mandate id and it will automatically get the last recurring contribution of the contact and its related installments and attach the mandate to them.
3- Then I use CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator, which basically adjusts the recurring contribution cycle date and start date as well as the first installment receive date to follow Direct debit specs.

Now when "webform_civicrm_membership_extras" take back control and try to create the remaining installments, all of them will get attached correctly to the mandate and they will have the correct receive date based on the first installment receive date, since only the first installment needs to have the correct data in order for the rest to follow.
