### PR TITLE
MAE-609: Enforce the new direct debit calculation logic on webforms.

### DIFF
--- a/webform_manualdd.module
+++ b/webform_manualdd.module
@@ -108,22 +108,9 @@ function webform_manualdd_webformmembershipextras_preCreatingUpfrontContribution
     return;
   }
 
-  // Attaching the mandate to both the first installment and the recurring contribution
   $contactId = _webformmanualdd_getContactId($node);
-  $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
-  $mandateId = $storageManager->getLastInsertedMandateId($contactId);
-  $storageManager->assignMandate($mandateId, $contactId);
-  
-  $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
-  $settings = $settingsManager->getManualDirectDebitSettings();
-  $mandateInfo = $storageManager->getMandate($mandateId);
-
-  // Updating both the first installment receive date and the recurring contribution start date
-  // to follow Direct Debit dates calculation logic.
-  $contributionDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator($contactId, $settings);
-  $contributionDataGenerator->setMandateStartDate($mandateInfo->start_date);
-  $contributionDataGenerator->generateContributionFieldsValues();
-  $contributionDataGenerator->saveGeneratedContributionValues();
+  _webformmanualdd_attachMandateToPayment($contactId);
+  _webformmanualdd_updatePaymentDates($contributionRecurId);
 }
 
 /**
@@ -172,4 +159,61 @@ function _webformmanualdd_getContactId($node) {
   }
 
   return $civiWebformEntityProperty['contact'][1]['id'];
+}
+
+/**
+ * Attaches the mandate to both the first installment and the recurring contribution.
+ *
+ * @param $contactId
+ */
+function _webformmanualdd_attachMandateToPayment($contactId) {
+  $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+  $mandateId = $storageManager->getLastInsertedMandateId($contactId);
+  $storageManager->assignMandate($mandateId, $contactId);
+}
+
+/**
+ * Updates both the first installment receive date and the recurring contribution start date
+ * to follow Direct Debit dates calculation logic.
+ *
+ * @param int $contributionRecurId
+ */
+function _webformmanualdd_updatePaymentDates($contributionRecurId) {
+  $hookParams = [
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  // If it is a monthly or quarterly, then there is only one (the first)
+  // installment at this point, if it is annual, then the first installment
+  // in the new term (in case or renewal) is the last contribution attached
+  // to the recurring contribution, and that is why we order by 'id DESC' with 'limit => 1'.
+  $firstInstallment = civicrm_api3('Contribution', 'get', [
+    'sequential' => 1,
+    'contribution_recur_id' => $contributionRecurId,
+    'options' => ['sort' => 'id DESC', 'limit' => 1],
+  ])['values'][0];
+  $firstInstallmentReceiveDate = $firstInstallment['receive_date'];
+
+  // calling the hook will alter the value $firstInstallmentReceiveDate to follow direct debit dates logic.
+  $dispatcher = new CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDate(1, $firstInstallmentReceiveDate, $hookParams);
+  $dispatcher->dispatch();
+
+  $frequencyUnit = civicrm_api3('ContributionRecur', 'getvalue', [
+    'return' => 'frequency_unit',
+    'id' => $contributionRecurId,
+  ]);
+  $newCycleDay = CRM_MembershipExtras_Service_CycleDayCalculator::calculate($firstInstallmentReceiveDate, $frequencyUnit);
+
+  civicrm_api3('Contribution', 'create', [
+    'sequential' => 1,
+    'id' => $firstInstallment['id'],
+    'receive_date' => $firstInstallmentReceiveDate,
+  ]);
+
+  civicrm_api3('ContributionRecur', 'create', [
+    'sequential' => 1,
+    'id' => $contributionRecurId,
+    'start_date' => $firstInstallmentReceiveDate,
+    'cycle_day' => $newCycleDay
+  ]);
 }


### PR DESCRIPTION
## Overview 

Here I enforce the new direct debit dates calculation logic by triggering membershipextras_calculateContributionReceiveDate hook to do so. Hence that it here covers the first installment receive date, the recurring contribution start date and the cycle day, the upfront contributions dates are calculated inside the manualdirectdebit extension and not here.

## Before

The first installment receive date, the recurring contribution start date and the cycle day are wrong for direct debit payment plans and does not  always respect direct debit extension configurations.

![2021-09-21 19_18_36-Groove Music](https://user-images.githubusercontent.com/6275540/134208483-8c991cd6-e815-457d-b1ed-d42a0eab0712.png)


![2021-09-21 19_17_34-dsaas@daad com dsaas@daad com _ civi5352v5](https://user-images.githubusercontent.com/6275540/134208368-a06ead36-479a-4e4e-a9d1-691c3ab73a3a.png)



## After

The first installment receive date, the recurring contribution start date and the cycle day are correct for direct debit payment plans and does respect direct debit extension configurations.

![2021-09-21 19_21_07-dadaskdsa@adad com dadaskdsa@adad com _ civi5352v5](https://user-images.githubusercontent.com/6275540/134209103-e95c033f-5001-441d-83c8-6c64a50b05b5.png)


![2021-09-21 19_22_33-dadaskdsa@adad com dadaskdsa@adad com _ civi5352v5](https://user-images.githubusercontent.com/6275540/134209113-2ce7c0a0-c58e-4fea-a505-0781745204c1.png)
